### PR TITLE
Refactor SOCKS5 constants and networking utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
-# libSocks5 Server
+# libSocks5
 
-The library implement a simple socks5 server with the particularity that the actual Sock5 Server and the targeted host where SockerTunnelClient run can be splited. Thus the Socks traffic can be encapsulated within another protocol like TCP/HTTP/SMB...
+A lightweight C++ SOCKS5 server and tunnel client for pivoting traffic through an intermediate host. The tunnel server accepts SOCKS5 connections, negotiates authentication and forwards data to a remote `SocksTunnelClient` running closer to the target network.
 
-proxychains ... <- tcp -> SocksServer <- http/tcp/smb -> SocksTunnelClient <- tcp -> target ip/port
-
+## Features
+- SOCKS5 CONNECT support with optional username/password authentication
+- Split architecture: public SOCKS server and tunnel client can run on different machines
+- Cross-platform build (Linux/Windows) using CMake
 
 ## Build
-
-```
-mkdir build
-cd build
+```bash
+mkdir build && cd build
 cmake ..
 make -j4
 ```
 
-Run SocksServer localy:
-
-```
+## Usage
+1. Launch the test server:
+```bash
 ./TestsSocksServer
-
-proxychains nmap -sT -sC -sV 127.0.0.1 -p 1080
-proxychains curl http://127.0.0.1:8080/test
 ```
+2. Point a SOCKS-aware client at `localhost:1080` (e.g., `proxychains curl http://example.com`).
+
+## Notes
+This project is a proof-of-concept; error handling and robustness are limited. Run behind a firewall and avoid exposing it to untrusted networks.

--- a/src/SocksDef.hpp
+++ b/src/SocksDef.hpp
@@ -1,33 +1,52 @@
 #pragma once
 
 #ifdef __linux__
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/select.h>
 #elif _WIN32
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #include <windows.h>
 #endif
 
+#include <cstdint>
+#include <cstddef>
+#include <iostream>
 
-#define BUF_SIZE 2048
+static constexpr std::size_t BUF_SIZE = 2048;
 
-// Command constants 
-#define CMD_CONNECT         1
-#define CMD_BIND            2
-#define CMD_UDP_ASSOCIATIVE 3
+// Command constants
+enum class Command : uint8_t
+{
+    Connect = 1,
+    Bind = 2,
+    UdpAssociate = 3
+};
 
-// Address type constants 
-#define ATYP_IPV4   1
-#define ATYP_DNAME  3
-#define ATYP_IPV6   4
+// Address type constants
+enum class AddressType : uint8_t
+{
+    IPv4 = 1,
+    DName = 3,
+    IPv6 = 4
+};
 
-// Connection methods 
-#define ALLOW_NO_AUTH
-#define METHOD_NOAUTH       0
-#define METHOD_AUTH         2
-#define METHOD_NOTAVAILABLE 0xff
+// Connection methods
+constexpr bool ALLOW_NO_AUTH = true;
+enum class Method : uint8_t
+{
+    NoAuth = 0,
+    Auth = 2,
+    NotAvailable = 0xff
+};
 
 // Responses
-#define RESP_SUCCEDED       0
-#define RESP_GEN_ERROR      1
+enum class Response : uint8_t
+{
+    Succeded = 0,
+    GenError = 1
+};
 
 // windows compatibility
 #ifndef _SSIZE_T_DEFINED
@@ -43,9 +62,48 @@ typedef unsigned __int64    ssize_t;
 
 
 // handle sig_pipe that can crash the app otherwise
-inline void sig_handler(int signum) 
+inline void sig_handler(int signum)
 {
+    std::cerr << "signal(" << signum << ")" << std::endl;
 }
+
+class SocketHandle
+{
+public:
+    SocketHandle() : m_fd(-1) {}
+    explicit SocketHandle(int fd) : m_fd(fd) {}
+    ~SocketHandle() { reset(); }
+    SocketHandle(const SocketHandle&) = delete;
+    SocketHandle& operator=(const SocketHandle&) = delete;
+    SocketHandle(SocketHandle&& other) noexcept : m_fd(other.m_fd) { other.m_fd = -1; }
+    SocketHandle& operator=(SocketHandle&& other) noexcept
+    {
+        if(this != &other)
+        {
+            reset();
+            m_fd = other.m_fd;
+            other.m_fd = -1;
+        }
+        return *this;
+    }
+    int get() const { return m_fd; }
+    void reset(int fd = -1)
+    {
+        if(m_fd != -1)
+        {
+#ifdef __linux__
+            ::shutdown(m_fd, SHUT_RDWR);
+            ::close(m_fd);
+#elif _WIN32
+            ::shutdown(m_fd, SHUT_RDWR);
+            ::closesocket(m_fd);
+#endif
+        }
+        m_fd = fd;
+    }
+private:
+    int m_fd;
+};
 
 
 inline int recv_sock(int sock, char *buffer, uint32_t size) 
@@ -77,51 +135,38 @@ inline int send_sock(int sock, const char *buffer, uint32_t size)
 }
 
 
-inline bool readAllDataFromSocket(int sockfd, char* buffer, int &bytes_received)
+enum class SocketReadStatus
+{
+    Timeout,
+    Success,
+    Disconnected,
+    Error
+};
+
+inline SocketReadStatus readAllDataFromSocket(int sockfd, char* buffer, int &bytes_received, int timeout_ms)
 {
     fd_set readfds;
-    bytes_received=0;
-    struct timeval timeout;
-
-    // Initialize the file descriptor set
+    bytes_received = 0;
     FD_ZERO(&readfds);
     FD_SET(sockfd, &readfds);
 
-    // TODO how to Set timeout, now 10ms
-    timeout.tv_sec = 0;
-    timeout.tv_usec = 10000;
+    struct timeval timeout;
+    timeout.tv_sec = timeout_ms / 1000;
+    timeout.tv_usec = (timeout_ms % 1000) * 1000;
 
     int activity = select(sockfd + 1, &readfds, NULL, NULL, &timeout);
-
-    bool isDataAvailable=false;
-    if (activity < 0) 
+    if (activity < 0)
+        return SocketReadStatus::Error;
+    if (activity == 0)
+        return SocketReadStatus::Timeout;
+    if (FD_ISSET(sockfd, &readfds))
     {
-        // perror("select error");
-    } else if (activity == 0) 
-    {
-        // printf("Timeout: No data available to read\n");
-    } 
-    else 
-    {
-        if (FD_ISSET(sockfd, &readfds)) 
-        {
-            isDataAvailable=true;
-            // Data is available to read
-            bytes_received = recv(sockfd, buffer, BUF_SIZE, 0);
-            if (bytes_received == -1) 
-            {
-                // perror("recv failed");
-            } 
-            else if (bytes_received == 0) 
-            {
-                // printf("Connection closed by peer\n");
-            } 
-            else 
-            {
-                // printf("Received: %d\n", bytes_received);
-            }
-        }
+        bytes_received = recv(sockfd, buffer, BUF_SIZE, 0);
+        if (bytes_received > 0)
+            return SocketReadStatus::Success;
+        if (bytes_received == 0)
+            return SocketReadStatus::Disconnected;
+        return SocketReadStatus::Error;
     }
-
-    return isDataAvailable;
+    return SocketReadStatus::Timeout;
 }

--- a/src/SocksServer.cpp
+++ b/src/SocksServer.cpp
@@ -101,7 +101,7 @@ struct SOCKS5Response
     uint32_t ip_src;
     uint16_t port_src;
     
-    SOCKS5Response(bool succeded = true) : version(5), cmd(succeded ? RESP_SUCCEDED : RESP_GEN_ERROR), rsv(0), atyp(ATYP_IPV4) { }
+    SOCKS5Response(bool succeded = true) : version(5), cmd(succeded ? static_cast<uint8_t>(Response::Succeded) : static_cast<uint8_t>(Response::GenError)), rsv(0), atyp(static_cast<uint8_t>(AddressType::IPv4)) { }
 } 
 #ifdef __linux__
     __attribute__((packed));
@@ -168,17 +168,7 @@ SocksTunnelServer::SocksTunnelServer(int serverfd, int serverPort, int id)
 }
 
 
-SocksTunnelServer::~SocksTunnelServer()
-{
-    #ifdef __linux__
-        shutdown(m_serverfd, SHUT_RDWR);
-        m_serverfd=-1;
-        close(m_serverfd);    
-    #elif _WIN32
-        closesocket(m_serverfd);    
-        m_serverfd=-1;
-    #endif
-}
+SocksTunnelServer::~SocksTunnelServer() = default;
 
 
 int SocksTunnelServer::init()
@@ -190,76 +180,46 @@ int SocksTunnelServer::init()
     // we are in the TeamServer
 
     MethodIdentificationPacket packet;
-    int read_size = recv_sock(m_serverfd, (char*)&packet, sizeof(MethodIdentificationPacket));
+    int read_size = recv_sock(m_serverfd.get(), (char*)&packet, sizeof(MethodIdentificationPacket));
 
     if(read_size != sizeof(MethodIdentificationPacket) || packet.version != 5)
     {
         std::cout << "[-] Wrong version of proxychain, only proxychain5 is supported." << std::endl;
-        #ifdef __linux__
-            shutdown(m_serverfd, SHUT_RDWR);
-            m_serverfd=-1;
-            close(m_serverfd);    
-        #elif _WIN32
-            closesocket(m_serverfd);    
-            m_serverfd=-1;
-        #endif
+        m_serverfd.reset();
         return 0;
     }
 
-    read_size = recv_sock(m_serverfd, &m_internalBuffer[0], packet.nmethods);
+    read_size = recv_sock(m_serverfd.get(), &m_internalBuffer[0], packet.nmethods);
 
     if(read_size != packet.nmethods)
     {
-        #ifdef __linux__
-            shutdown(m_serverfd, SHUT_RDWR);
-            m_serverfd=-1;
-            close(m_serverfd);    
-        #elif _WIN32
-            closesocket(m_serverfd);    
-            m_serverfd=-1;
-        #endif
+        m_serverfd.reset();
         return 0;
     }
 
-    MethodSelectionPacket methode_response(METHOD_NOTAVAILABLE);
-    for(unsigned i(0); i < packet.nmethods; ++i) 
+    MethodSelectionPacket methode_response(static_cast<uint8_t>(Method::NotAvailable));
+    for(unsigned i(0); i < packet.nmethods; ++i)
     {
-        #ifdef ALLOW_NO_AUTH
-            if(m_internalBuffer[i] == METHOD_NOAUTH)
-                methode_response.method = METHOD_NOAUTH;
-        #endif
-        if(m_internalBuffer[i] == METHOD_AUTH)
-            methode_response.method = METHOD_AUTH;
+        if(ALLOW_NO_AUTH && m_internalBuffer[i] == static_cast<uint8_t>(Method::NoAuth))
+            methode_response.method = static_cast<uint8_t>(Method::NoAuth);
+        if(m_internalBuffer[i] == static_cast<uint8_t>(Method::Auth))
+            methode_response.method = static_cast<uint8_t>(Method::Auth);
     }
 
-    int write_size = send_sock(m_serverfd, (const char*)&methode_response, sizeof(MethodSelectionPacket)) ;
+    int write_size = send_sock(m_serverfd.get(), (const char*)&methode_response, sizeof(MethodSelectionPacket)) ;
 
     // std::cout << "MethodSelectionPacket " << std::to_string(write_size) << std::endl;
 
-    if(write_size != sizeof(MethodSelectionPacket) || methode_response.method == METHOD_NOTAVAILABLE)
+    if(write_size != sizeof(MethodSelectionPacket) || methode_response.method == static_cast<uint8_t>(Method::NotAvailable))
     {
-        #ifdef __linux__
-            shutdown(m_serverfd, SHUT_RDWR);
-            m_serverfd=-1;
-            close(m_serverfd);    
-        #elif _WIN32
-            closesocket(m_serverfd);    
-            m_serverfd=-1;
-        #endif
+        m_serverfd.reset();
         return 0;
     }
 
-    if(methode_response.method == METHOD_AUTH)
-        if(!check_auth(m_serverfd))
+    if(methode_response.method == static_cast<uint8_t>(Method::Auth))
+        if(!check_auth(m_serverfd.get()))
         {
-            #ifdef __linux__
-                shutdown(m_serverfd, SHUT_RDWR);
-                m_serverfd=-1;
-                close(m_serverfd);    
-            #elif _WIN32
-                closesocket(m_serverfd);    
-                m_serverfd=-1;
-            #endif
+            m_serverfd.reset();
             return 0;
         }
 
@@ -267,51 +227,30 @@ int SocksTunnelServer::init()
     std::cout << "[+] HandShake ok" << std::endl;   
 
     SOCKS5RequestHeader header;
-    read_size = recv_sock(m_serverfd, (char*)&header, sizeof(SOCKS5RequestHeader));
+    read_size = recv_sock(m_serverfd.get(), (char*)&header, sizeof(SOCKS5RequestHeader));
 
-    if(read_size != sizeof(SOCKS5RequestHeader) || header.version != 5 || header.cmd != CMD_CONNECT || header.rsv != 0)
+    if(read_size != sizeof(SOCKS5RequestHeader) || header.version != 5 || header.cmd != static_cast<uint8_t>(Command::Connect) || header.rsv != 0)
     {
-        #ifdef __linux__
-            shutdown(m_serverfd, SHUT_RDWR);
-            m_serverfd=-1;
-            close(m_serverfd);    
-        #elif _WIN32
-            closesocket(m_serverfd);    
-            m_serverfd=-1;
-        #endif
+        m_serverfd.reset();
         return 0;
     }
 
     // std::cout << "SOCKS5RequestHeader " << std::to_string(read_size) << std::endl;
 
-    if(header.atyp != ATYP_IPV4)
+    if(header.atyp != static_cast<uint8_t>(AddressType::IPv4))
     {
-        #ifdef __linux__
-            shutdown(m_serverfd, SHUT_RDWR);
-            m_serverfd=-1;
-            close(m_serverfd);    
-        #elif _WIN32
-            closesocket(m_serverfd);    
-            m_serverfd=-1;
-        #endif
+        m_serverfd.reset();
         return 0;
     }
 
     SOCK5IP4RequestBody req;
-    read_size = recv_sock(m_serverfd, (char*)&req, sizeof(SOCK5IP4RequestBody));
+    read_size = recv_sock(m_serverfd.get(), (char*)&req, sizeof(SOCK5IP4RequestBody));
 
     // std::cout << "SOCK5IP4RequestBody " << std::to_string(read_size) << std::endl;
 
     if(read_size != sizeof(SOCK5IP4RequestBody))
     {
-        #ifdef __linux__
-            shutdown(m_serverfd, SHUT_RDWR);
-            m_serverfd=-1;
-            close(m_serverfd);    
-        #elif _WIN32
-            closesocket(m_serverfd);    
-            m_serverfd=-1;
-        #endif
+        m_serverfd.reset();
         return 0;
     }
 
@@ -322,12 +261,12 @@ int SocksTunnelServer::init()
 }
 
 
-int SocksTunnelServer::finishHandshack()
+int SocksTunnelServer::finishHandshake()
 {
     SOCKS5Response response;
     response.ip_src = 0;
     response.port_src = m_serverPort;
-    send_sock(m_serverfd, (const char*)&response, sizeof(SOCKS5Response));
+    send_sock(m_serverfd.get(), (const char*)&response, sizeof(SOCKS5Response));
 
     return 1;
 }
@@ -336,14 +275,14 @@ int SocksTunnelServer::finishHandshack()
 int SocksTunnelServer::process(std::string& dataIn, std::string& dataOut)
 {
     if(dataIn.size()>0)
-        send_sock(m_serverfd, dataIn.data(), dataIn.size());
+        send_sock(m_serverfd.get(), dataIn.data(), dataIn.size());
 
     int bytes_received;
-    bool isDataAvailable;
-
-    isDataAvailable = readAllDataFromSocket(m_serverfd, &m_internalBuffer[0], bytes_received);
-    if(isDataAvailable && bytes_received <= 0)
+    SocketReadStatus status = readAllDataFromSocket(m_serverfd.get(), &m_internalBuffer[0], bytes_received, 10);
+    if(status == SocketReadStatus::Error || status == SocketReadStatus::Disconnected)
         return -1;
+    if(status == SocketReadStatus::Timeout)
+        bytes_received = 0;
 
     dataOut.assign(&m_internalBuffer[0], bytes_received);
 
@@ -384,14 +323,7 @@ void SocksServer::launch()
 void SocksServer::stop()
 {
     m_isStoped=true;
-    #ifdef __linux__
-        shutdown(m_listen_sock, SHUT_RDWR);
-        m_listen_sock=-1;
-        close(m_listen_sock);    
-    #elif _WIN32
-        closesocket(m_listen_sock);    
-        m_listen_sock=-1;
-    #endif
+    m_listen_sock.reset();
 
     if(m_socks5Server)
     {
@@ -461,36 +393,32 @@ int SocksServer::createServerSocket(struct sockaddr_in &echoclient)
 int SocksServer::handleConnection()
 {
     struct sockaddr_in echoclient;
-    m_listen_sock = createServerSocket(echoclient);
-    
-    if(m_listen_sock == -1) 
+    m_listen_sock.reset(createServerSocket(echoclient));
+
+    if(m_listen_sock.get() == -1)
     {
         std::cout << "[-] Failed to create server\n";
         return -1;
     }
 
-    #ifdef __linux__
-        signal(SIGPIPE, sig_handler);  
-    #elif _WIN32  
-    #endif
-
+#ifdef __linux__
+    signal(SIGPIPE, sig_handler);
+#elif _WIN32
+#endif
 
     m_isStoped = false;
     m_isLaunched = true;
     int idSocksTunnelServer=0;
-    while(!m_isStoped) 
+    while(!m_isStoped)
     {
         int clientlen = sizeof(echoclient);
         int clientsock;
-        #ifdef __linux__
-        if ((clientsock = accept(m_listen_sock, (struct sockaddr *) &echoclient, (uint*)&clientlen)) > 0) 
-        #elif _WIN32
-        if ((clientsock = accept(m_listen_sock, (struct sockaddr *) &echoclient, &clientlen)) > 0) 
-        #endif 
+#ifdef __linux__
+        if ((clientsock = accept(m_listen_sock.get(), (struct sockaddr *) &echoclient, (uint*)&clientlen)) > 0)
+#elif _WIN32
+        if ((clientsock = accept(m_listen_sock.get(), (struct sockaddr *) &echoclient, &clientlen)) > 0)
+#endif
         {
-            // 
-            // mode indirect
-            //
             std::unique_ptr<SocksTunnelServer> socksTunnelServer = std::make_unique<SocksTunnelServer>(clientsock, m_serverPort, idSocksTunnelServer);
             int initResult = socksTunnelServer->init();
             if(initResult)
@@ -498,24 +426,13 @@ int SocksServer::handleConnection()
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_socksTunnelServers.push_back(std::move(socksTunnelServer));
             }
-            else
-            {
-                // printf("SocksTunnelServer init failed\n");
-            }
             idSocksTunnelServer++;
         }
     }
 
     std::cout << "[+] handleConnection stoped\n";
 
-    #ifdef __linux__
-        shutdown(m_listen_sock, SHUT_RDWR);
-        m_listen_sock=-1;
-        close(m_listen_sock);    
-    #elif _WIN32
-        closesocket(m_listen_sock);    
-        m_listen_sock=-1;
-    #endif
+    m_listen_sock.reset();
 
     return 1;
 }
@@ -527,4 +444,25 @@ void SocksServer::cleanTunnel()
     m_socksTunnelServers.erase(std::remove_if(m_socksTunnelServers.begin(), m_socksTunnelServers.end(),
                              [](const std::unique_ptr<SocksTunnelServer>& ptr) { return ptr == nullptr; }),
               m_socksTunnelServers.end());
+}
+
+std::size_t SocksServer::tunnelCount()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_socksTunnelServers.size();
+}
+
+SocksTunnelServer* SocksServer::getTunnel(std::size_t idx)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if(idx >= m_socksTunnelServers.size())
+        return nullptr;
+    return m_socksTunnelServers[idx].get();
+}
+
+void SocksServer::resetTunnel(std::size_t idx)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if(idx < m_socksTunnelServers.size())
+        m_socksTunnelServers[idx].reset();
 }

--- a/src/SocksServer.hpp
+++ b/src/SocksServer.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <mutex>
 
+#include "SocksDef.hpp"
 
 enum class SocksState 
 {
@@ -21,7 +22,7 @@ class SocksTunnelServer
         ~SocksTunnelServer();
 
         int init();
-        int finishHandshack();
+        int finishHandshake();
         int process(std::string& dataIn, std::string& dataOut);
 
         uint32_t getIpDst()
@@ -46,7 +47,7 @@ class SocksTunnelServer
         }
 
     private:
-        int m_serverfd;
+        SocketHandle m_serverfd;
         int m_serverPort;
 
         uint32_t m_ipDst;
@@ -64,7 +65,7 @@ class SocksServer
 
 public:
     SocksServer(int serverPort=1080);
-    ~SocksServer(); 
+    ~SocksServer();
 
     void launch();
     void stop();
@@ -78,7 +79,9 @@ public:
         return m_isLaunched;
     }
 
-    std::vector<std::unique_ptr<SocksTunnelServer>> m_socksTunnelServers;
+    std::size_t tunnelCount();
+    SocksTunnelServer* getTunnel(std::size_t idx);
+    void resetTunnel(std::size_t idx);
 
 private:
     int createListenSocket(struct sockaddr_in &echoclient) ;
@@ -86,11 +89,12 @@ private:
     int handleConnection();
 
     int m_serverPort;
-    int m_listen_sock;
+    SocketHandle m_listen_sock;
 
     bool m_isLaunched;
     bool m_isStoped;
     std::unique_ptr<std::thread> m_socks5Server;
 
-    std::mutex m_mutex;    
+    std::mutex m_mutex;
+    std::vector<std::unique_ptr<SocksTunnelServer>> m_socksTunnelServers;
 };

--- a/src/SocksTunnelClient.cpp
+++ b/src/SocksTunnelClient.cpp
@@ -22,41 +22,6 @@
 using namespace std;
 
 
-#ifdef __linux__
-
-class Lock 
-{
-    pthread_mutex_t mutex;
-public:
-    Lock() 
-    {
-        pthread_mutex_init(&mutex, NULL);
-    }
-  
-    ~Lock() 
-    {
-        pthread_mutex_destroy(&mutex);
-    }
-    
-    inline void lock() 
-    {
-        pthread_mutex_lock(&mutex);
-    }
-    
-    inline void unlock() 
-    {
-        pthread_mutex_unlock(&mutex);
-    }
-};
-
-
-Lock get_host_lock;
-
-#elif _WIN32
-
-#endif
-
-
 std::string int_to_str(uint32_t ip) 
 {
     ostringstream oss;
@@ -70,44 +35,49 @@ std::string int_to_str(uint32_t ip)
 }
 
 
-int connect_to_host(uint32_t ip, uint16_t port) 
+int connect_to_host(uint32_t ip, uint16_t port)
 {
-    
     struct sockaddr_in serv_addr;
-    struct hostent *server;
     int sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (sockfd < 0)
     {
-        // int errorsocket = WSAGetLastError();
-        // std::cout << "errorsocket return code " << errorsocket << std::endl;
         return -1;
     }
 
-    memset((char *) &serv_addr, 0, sizeof(serv_addr));
-    serv_addr.sin_family = AF_INET; 
     std::string ip_string = int_to_str(ip);
 
-#ifdef __linux__   
-    
-    get_host_lock.lock();
-    server = gethostbyname(ip_string.c_str());
-    if(!server) 
+    struct addrinfo hints, *res = nullptr;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    if (getaddrinfo(ip_string.c_str(), nullptr, &hints, &res) != 0)
     {
-        get_host_lock.unlock();
+#ifdef __linux__
+        close(sockfd);
+#elif _WIN32
+        closesocket(sockfd);
+#endif
         return -1;
     }
-    bcopy((char *)server->h_addr, (char *)&serv_addr.sin_addr.s_addr, server->h_length);
-    get_host_lock.unlock();
 
-#elif _WIN32
-
-    inet_pton(AF_INET, ip_string.c_str(), &serv_addr.sin_addr.s_addr);
-
-#endif
-    
+    memset(&serv_addr, 0, sizeof(serv_addr));
+    serv_addr.sin_family = AF_INET;
+    serv_addr.sin_addr = ((struct sockaddr_in*)res->ai_addr)->sin_addr;
     serv_addr.sin_port = htons(port);
+    freeaddrinfo(res);
 
-    return !connect(sockfd, (const sockaddr*)&serv_addr, sizeof(serv_addr)) ? sockfd : -1;
+    if (connect(sockfd, (const sockaddr*)&serv_addr, sizeof(serv_addr)) != 0)
+    {
+#ifdef __linux__
+        close(sockfd);
+#elif _WIN32
+        closesocket(sockfd);
+#endif
+        return -1;
+    }
+
+    return sockfd;
 }
 
 
@@ -129,13 +99,8 @@ SocksTunnelClient::SocksTunnelClient(int id)
 
 SocksTunnelClient::~SocksTunnelClient()
 {
-    shutdown(m_clientfd, SHUT_RDWR);
-
-#ifdef __linux__
-    close(m_clientfd);    
-#elif _WIN32
+#ifdef _WIN32
     WSACleanup();
-    closesocket(m_clientfd);    
 #endif
 }
 
@@ -148,8 +113,8 @@ int SocksTunnelClient::init(uint32_t ip_dst, uint16_t port)
      
 #endif
 
-    m_clientfd = connect_to_host(ip_dst, ntohs(port));
-    if(m_clientfd == -1)
+    m_clientfd.reset(connect_to_host(ip_dst, ntohs(port)));
+    if(m_clientfd.get() == -1)
     {
         return 0;
     }
@@ -161,17 +126,15 @@ int SocksTunnelClient::init(uint32_t ip_dst, uint16_t port)
 int SocksTunnelClient::process(const std::string& dataIn, std::string& dataOut)
 {
     if(dataIn.size()>0)
-        send_sock(m_clientfd, dataIn.data(), dataIn.size());
+        send_sock(m_clientfd.get(), dataIn.data(), dataIn.size());
 
     int bytes_received;
-    bool isDataAvailable;
+    SocketReadStatus status = readAllDataFromSocket(m_clientfd.get(), &m_internalBuffer[0], bytes_received, 10);
 
-    isDataAvailable = readAllDataFromSocket(m_clientfd, &m_internalBuffer[0], bytes_received);
-
-    // std::cout << "isDataAvailable " << isDataAvailable << " " << "bytes_received " << bytes_received << std::endl;
-
-    if(isDataAvailable && bytes_received <= 0)
+    if(status == SocketReadStatus::Error || status == SocketReadStatus::Disconnected)
         return -1;
+    if(status == SocketReadStatus::Timeout)
+        bytes_received = 0;
 
     dataOut.assign(&m_internalBuffer[0], bytes_received);
 

--- a/src/SocksTunnelClient.hpp
+++ b/src/SocksTunnelClient.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "SocksDef.hpp"
 
 class SocksTunnelClient
 {
     public:
         SocksTunnelClient(int id=0);
-        ~SocksTunnelClient(); 
+        ~SocksTunnelClient();
 
         int init(uint32_t ip_dst, uint16_t port);
         int process(const std::string& dataIn, std::string& dataOut);
@@ -17,7 +18,7 @@ class SocksTunnelClient
 
     private:
         int m_id;
-        int m_clientfd;
+        SocketHandle m_clientfd;
 
         std::string m_internalBuffer;
 };

--- a/tests/TestsSocksServer.cpp
+++ b/tests/TestsSocksServer.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <chrono>
 #include <thread>
+#include <cstdint>
 
 #include "SocksServer.hpp"
 #include "SocksTunnelClient.hpp"
@@ -12,28 +13,30 @@ int main(int argc, char *argv[])
     SocksServer socksServer(1080);
     socksServer.launch();
 
-    while(1)
+    int iterations = 0;
+    while(iterations < 50)
     {
-        for(int i=0; i<socksServer.m_socksTunnelServers.size(); i++)
+        for(std::size_t i=0; i<socksServer.tunnelCount(); i++)
         {
-            std::cout << "main loop idx " << std::to_string(i) << std::endl;
-            if(socksServer.m_socksTunnelServers[i]!=nullptr)
+            std::cout << "main loop idx " << i << std::endl;
+            SocksTunnelServer* tunnel = socksServer.getTunnel(i);
+            if(tunnel)
             {
-                std::cout << "GO " << std::to_string(i) << std::endl;
+                std::cout << "GO " << i << std::endl;
 
-                uint32_t ip = socksServer.m_socksTunnelServers[i]->getIpDst();
-                uint16_t port = socksServer.m_socksTunnelServers[i]->getPort();
+                uint32_t ip = tunnel->getIpDst();
+                uint16_t port = tunnel->getPort();
 
                 SocksTunnelClient socksTunnelClient;
                 socksTunnelClient.init(ip, port);
 
-                socksServer.m_socksTunnelServers[i]->finishHandshack();
+                tunnel->finishHandshake();
 
                 std::string dataIn;
                 std::string dataOut;
-                while(1)
+                while(true)
                 {
-                    int res = socksServer.m_socksTunnelServers[i]->process(dataIn, dataOut);
+                    int res = tunnel->process(dataIn, dataOut);
                     if(res<=0)
                         break;
 
@@ -42,12 +45,13 @@ int main(int argc, char *argv[])
                         break;
                 }
 
-                std::cout << "End    " << std::to_string(i) << std::endl;
+                std::cout << "End    " << i << std::endl;
 
-                socksServer.m_socksTunnelServers[i].reset(nullptr);
+                socksServer.resetTunnel(i);
             }
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        iterations++;
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- replace preprocessor constants with scoped enums and constexpr values
- add RAII `SocketHandle`, improved SIGPIPE handling, and richer socket read status
- encapsulate tunnel management and modernize DNS lookup with `getaddrinfo`

## Testing
- `cmake .. && make -j4`
- `./tests/TestsSocksServer`


------
https://chatgpt.com/codex/tasks/task_e_68b030d3e94c83258ada10101d3e7183